### PR TITLE
Return search results with score

### DIFF
--- a/include/searcher.h
+++ b/include/searcher.h
@@ -27,7 +27,6 @@
 
 #include <opencv2/core/core.hpp>
 
-
 using namespace std;
 using namespace cv;
 
@@ -40,6 +39,7 @@ struct SearchRequest
     ClientConnection *client;
     vector<u_int32_t> results;
     vector<Rect> boundingRects;
+    vector<float> scores;
 };
 
 

--- a/src/orb/orbsearcher.cpp
+++ b/src/orb/orbsearcher.cpp
@@ -265,6 +265,7 @@ void ORBSearcher::returnResults(priority_queue<SearchResult> &rankedResults,
         cout << "Id: " << res.i_imageId << ", score: " << res.f_weight << endl;
         req.results.push_back(res.i_imageId);
         req.boundingRects.push_back(res.boundingRect);
+        req.scores.push_back(res.f_weight);
         rankedResults.pop();
     }
 }

--- a/src/requesthandler.cpp
+++ b/src/requesthandler.cpp
@@ -167,6 +167,12 @@ void RequestHandler::handleRequest(ConnectionInfo &conInfo)
                 boundingRects.append(rVal);
             }
             ret["bounding_rects"] = boundingRects;
+
+            // Return the scores
+            Json::Value scores(Json::arrayValue);
+            for (unsigned i = 0; i < req.scores.size(); ++i)
+                scores.append(req.scores[i]);
+            ret["scores"] = scores;
         }
     }
     else if (testURIWithPattern(parsedURI, p_ioIndex)


### PR DESCRIPTION
I think it can be useful to return each search result with the score, as this may enable clients searching for images to determine which results are good enough for their specific use of Pastec.

Example response:

``` json
{
   "bounding_rects" : [
      {
         "height" : 381,
         "width" : 394,
         "x" : 73,
         "y" : 31
      }
   ],
   "image_ids" : [
      {
         "id" : 19,
         "score" : 1201.0
      }
   ],
   "type" : "SEARCH_RESULTS"
}
```
