### PR TITLE
Add In-Index Similarity Search

### DIFF
--- a/include/orb/orbindex.h
+++ b/include/orb/orbindex.h
@@ -52,7 +52,7 @@ using namespace std::tr1;
 class ORBIndex : public Index
 {
 public:
-    ORBIndex(string indexPath);
+    ORBIndex(string indexPath, bool cacheImageWords);
     virtual ~ORBIndex();
     void getImagesWithVisualWords(unordered_map<u_int32_t, list<Hit> > &imagesReqHits,
                                   unordered_map<u_int32_t, vector<Hit> > &indexHitsForReq);
@@ -74,6 +74,7 @@ private:
 
     u_int64_t nbOccurences[NB_VISUAL_WORDS];
     u_int64_t totalNbRecords;
+    bool cacheImageWords;
 
     unordered_map<u_int64_t, unsigned> nbWords;
     unordered_map<u_int64_t, vector<unsigned> > imageWords;

--- a/include/orb/orbindex.h
+++ b/include/orb/orbindex.h
@@ -61,6 +61,7 @@ public:
     unsigned getTotalNbIndexedImages();
     u_int32_t addImage(unsigned i_imageId, list<HitForward> hitList);
     u_int32_t removeImage(const unsigned i_imageId);
+    u_int32_t getImageWords(const unsigned i_imageId, unordered_map<u_int32_t, list<Hit> > &hitList);
     u_int32_t write(string backwardIndexPath);
     u_int32_t clear();
     u_int32_t load(string backwardIndexPath);

--- a/include/orb/orbindex.h
+++ b/include/orb/orbindex.h
@@ -52,7 +52,7 @@ using namespace std::tr1;
 class ORBIndex : public Index
 {
 public:
-    ORBIndex(string indexPath, bool cacheImageWords);
+    ORBIndex(string indexPath, bool buildForwardIndex);
     virtual ~ORBIndex();
     void getImagesWithVisualWords(unordered_map<u_int32_t, list<Hit> > &imagesReqHits,
                                   unordered_map<u_int32_t, vector<Hit> > &indexHitsForReq);
@@ -74,10 +74,10 @@ private:
 
     u_int64_t nbOccurences[NB_VISUAL_WORDS];
     u_int64_t totalNbRecords;
-    bool cacheImageWords;
+    bool buildForwardIndex;
 
     unordered_map<u_int64_t, unsigned> nbWords;
-    unordered_map<u_int64_t, vector<unsigned> > imageWords;
+    unordered_map<u_int64_t, vector<unsigned> > forwardIndex;
     vector<Hit> indexHits[NB_VISUAL_WORDS];
 
     pthread_rwlock_t rwLock;

--- a/include/orb/orbindex.h
+++ b/include/orb/orbindex.h
@@ -76,6 +76,7 @@ private:
     u_int64_t totalNbRecords;
 
     unordered_map<u_int64_t, unsigned> nbWords;
+    unordered_map<u_int64_t, vector<unsigned> > imageWords;
     vector<Hit> indexHits[NB_VISUAL_WORDS];
 
     pthread_rwlock_t rwLock;

--- a/include/orb/orbsearcher.h
+++ b/include/orb/orbsearcher.h
@@ -45,6 +45,7 @@ public:
     ORBSearcher(ORBIndex *index, ORBWordIndex *wordIndex);
     virtual ~ORBSearcher();
     u_int32_t searchImage(SearchRequest &request);
+    u_int32_t searchSimilar(SearchRequest &request);
 
 private:
     void returnResults(priority_queue<SearchResult> &rankedResults,

--- a/include/orb/orbsearcher.h
+++ b/include/orb/orbsearcher.h
@@ -51,6 +51,8 @@ private:
     void returnResults(priority_queue<SearchResult> &rankedResults,
                        SearchRequest &req, unsigned i_maxNbResults);
     unsigned long getTimeDiff(const timeval t1, const timeval t2) const;
+    u_int32_t processSimilar(SearchRequest &request,
+                             unordered_map<u_int32_t, list<Hit> > imageReqHits);
 
     ORBIndex *index;
     ORBWordIndex *wordIndex;

--- a/include/searcher.h
+++ b/include/searcher.h
@@ -35,6 +35,7 @@ class ClientConnection;
 
 struct SearchRequest
 {
+    u_int32_t imageId;
     vector<char> imageData;
     ClientConnection *client;
     vector<u_int32_t> results;
@@ -47,6 +48,7 @@ class Searcher
 {
 public:
     virtual u_int32_t searchImage(SearchRequest &request) = 0;
+    virtual u_int32_t searchSimilar(SearchRequest &request) = 0;
 };
 
 #endif // PASTEC_SEARCHER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ void intHandler(int signum) {
 void printUsage()
 {
     cout << "Usage :" << endl
-         << "./PastecIndex [-p portNumber] [-i indexPath] visualWordList" << endl;
+         << "./PastecIndex [-p portNumber] [-i indexPath] [--cache-words] visualWordList" << endl;
 }
 
 
@@ -66,6 +66,7 @@ int main(int argc, char** argv)
     unsigned i_port = 4212;
     string visualWordPath;
     string indexPath(DEFAULT_INDEX_PATH);
+    bool cacheImageWords = false;
 
     int i = 1;
     while (i < argc)
@@ -80,6 +81,10 @@ int main(int argc, char** argv)
             EXIT_IF_LAST_ARGUMENT()
             indexPath = argv[++i];
         }
+        else if (string(argv[i]) == "--cache-words")
+        {
+            cacheImageWords = true;
+        }
         else if (i == argc - 1)
         {
             visualWordPath = argv[i];
@@ -92,7 +97,7 @@ int main(int argc, char** argv)
         ++i;
     }
 
-    Index *index = new ORBIndex(indexPath);
+    Index *index = new ORBIndex(indexPath, cacheImageWords);
     ORBWordIndex *wordIndex = new ORBWordIndex(visualWordPath);
     FeatureExtractor *ife = new ORBFeatureExtractor((ORBIndex *)index, wordIndex);
     Searcher *is = new ORBSearcher((ORBIndex *)index, wordIndex);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ void intHandler(int signum) {
 void printUsage()
 {
     cout << "Usage :" << endl
-         << "./PastecIndex [-p portNumber] [-i indexPath] [--cache-words] visualWordList" << endl;
+         << "./PastecIndex [-p portNumber] [-i indexPath] [--forward-index] visualWordList" << endl;
 }
 
 
@@ -66,7 +66,7 @@ int main(int argc, char** argv)
     unsigned i_port = 4212;
     string visualWordPath;
     string indexPath(DEFAULT_INDEX_PATH);
-    bool cacheImageWords = false;
+    bool buildForwardIndex = false;
 
     int i = 1;
     while (i < argc)
@@ -81,9 +81,9 @@ int main(int argc, char** argv)
             EXIT_IF_LAST_ARGUMENT()
             indexPath = argv[++i];
         }
-        else if (string(argv[i]) == "--cache-words")
+        else if (string(argv[i]) == "--forward-index")
         {
-            cacheImageWords = true;
+            buildForwardIndex = true;
         }
         else if (i == argc - 1)
         {
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
         ++i;
     }
 
-    Index *index = new ORBIndex(indexPath, cacheImageWords);
+    Index *index = new ORBIndex(indexPath, buildForwardIndex);
     ORBWordIndex *wordIndex = new ORBWordIndex(visualWordPath);
     FeatureExtractor *ife = new ORBFeatureExtractor((ORBIndex *)index, wordIndex);
     Searcher *is = new ORBSearcher((ORBIndex *)index, wordIndex);

--- a/src/orb/orbsearcher.cpp
+++ b/src/orb/orbsearcher.cpp
@@ -110,7 +110,7 @@ public:
  */
 u_int32_t ORBSearcher::searchImage(SearchRequest &request)
 {
-    timeval t[5];
+    timeval t[3];
     gettimeofday(&t[0], NULL);
 
     cout << "Loading the image and extracting the ORBs." << endl;
@@ -120,8 +120,6 @@ u_int32_t ORBSearcher::searchImage(SearchRequest &request)
                                              request.imageData.data(), img);
     if (i_ret != OK)
         return i_ret;
-
-    //equalizeHist( img, img );
 
     vector<KeyPoint> keypoints;
     Mat descriptors;
@@ -169,86 +167,10 @@ u_int32_t ORBSearcher::searchImage(SearchRequest &request)
         }
     }
 
-    cout << imageReqHits.size() << " visual words kept for the request." << endl;
-
-    cout << i_nbTotalIndexedImages << " images indexed in the index." << endl;
-
-    unordered_map<u_int32_t, vector<Hit> > indexHits; // key: visual word id, values: index hits.
-    indexHits.rehash(imageReqHits.size());
-    index->getImagesWithVisualWords(imageReqHits, indexHits);
-
     gettimeofday(&t[2], NULL);
     cout << "time: " << getTimeDiff(t[1], t[2]) << " ms." << endl;
-    cout << "Ranking the images." << endl;
 
-    index->readLock();
-    #define NB_RANKING_THREAD 4
-
-    // Map the ranking to threads.
-    unsigned i_wordsPerThread = indexHits.size() / NB_RANKING_THREAD + 1;
-    RankingThread *threads[NB_RANKING_THREAD];
-
-    unordered_map<u_int32_t, vector<Hit> >::const_iterator it = indexHits.begin();
-    for (unsigned i = 0; i < NB_RANKING_THREAD; ++i)
-    {
-        threads[i] = new RankingThread(index, i_nbTotalIndexedImages, indexHits);
-
-        unsigned i_nbWords = 0;
-        for (; it != indexHits.end() && i_nbWords < i_wordsPerThread; ++it, ++i_nbWords)
-            threads[i]->addWord(it->first);
-    }
-
-    // Compute
-    for (unsigned i = 0; i < NB_RANKING_THREAD; ++i)
-        threads[i]->start();
-    for (unsigned i = 0; i < NB_RANKING_THREAD; ++i)
-        threads[i]->join();
-
-    // Reduce...
-    unordered_map<u_int32_t, float> weights; // key: image id, value: image score.
-    weights.rehash(i_nbTotalIndexedImages);
-    for (unsigned i = 0; i < NB_RANKING_THREAD; ++i)
-        for (unordered_map<u_int32_t, float>::const_iterator it = threads[i]->weights.begin();
-            it != threads[i]->weights.end(); ++it)
-            weights[it->first] += it->second;
-
-    // Free the memory
-    for (unsigned i = 0; i < NB_RANKING_THREAD; ++i)
-        delete threads[i];
-
-    index->unlock();
-
-    priority_queue<SearchResult> rankedResults;
-    for (unordered_map<unsigned, float>::const_iterator it = weights.begin();
-         it != weights.end(); ++it)
-        rankedResults.push(SearchResult(it->second, it->first, Rect()));
-
-    gettimeofday(&t[3], NULL);
-    cout << "time: " << getTimeDiff(t[2], t[3]) << " ms." << endl;
-    cout << "Reranking 300 among " << rankedResults.size() << " images." << endl;
-
-    priority_queue<SearchResult> rerankedResults;
-    reranker.rerank(imageReqHits, indexHits,
-                    rankedResults, rerankedResults, 300);
-
-    gettimeofday(&t[4], NULL);
-    cout << "time: " << getTimeDiff(t[3], t[4]) << " ms." << endl;
-    cout << "Returning the results. " << endl;
-
-    returnResults(rerankedResults, request, 100);
-
-#if 0
-    // Draw keypoints and ellipses.
-    Mat img_res;
-    drawKeypoints(img, cleanKeypoints, img_res, Scalar::all(-1), DrawMatchesFlags::DEFAULT);
-    for (unsigned i = 0; i < ellipses.size(); ++i)
-        ellipse( img_res, ellipses[i], Scalar(0, 0, 255), 1);
-
-    // Show the image.
-    imshow("Keypoints 1", img_res);
-#endif
-
-    return SEARCH_RESULTS;
+    return processSimilar(request, imageReqHits);
 }
 
 
@@ -258,10 +180,8 @@ u_int32_t ORBSearcher::searchImage(SearchRequest &request)
  */
 u_int32_t ORBSearcher::searchSimilar(SearchRequest &request)
 {
-    timeval t[5];
+    timeval t[2];
     gettimeofday(&t[0], NULL);
-
-    const unsigned i_nbTotalIndexedImages = index->getTotalNbIndexedImages();
 
     cout << "Loading the image words from the index." << endl;
 
@@ -273,8 +193,20 @@ u_int32_t ORBSearcher::searchSimilar(SearchRequest &request)
         return i_ret;
 
     gettimeofday(&t[1], NULL);
-
     cout << "time: " << getTimeDiff(t[0], t[1]) << " ms." << endl;
+
+    return processSimilar(request, imageReqHits);
+}
+
+
+u_int32_t ORBSearcher::processSimilar(SearchRequest &request,
+        unordered_map<u_int32_t, list<Hit> > imageReqHits)
+{
+    timeval t[4];
+    gettimeofday(&t[0], NULL);
+
+    const unsigned i_nbTotalIndexedImages = index->getTotalNbIndexedImages();
+
     cout << imageReqHits.size() << " visual words kept for the request." << endl;
     cout << i_nbTotalIndexedImages << " images indexed in the index." << endl;
 
@@ -282,8 +214,8 @@ u_int32_t ORBSearcher::searchSimilar(SearchRequest &request)
     indexHits.rehash(imageReqHits.size());
     index->getImagesWithVisualWords(imageReqHits, indexHits);
 
-    gettimeofday(&t[2], NULL);
-    cout << "time: " << getTimeDiff(t[1], t[2]) << " ms." << endl;
+    gettimeofday(&t[1], NULL);
+    cout << "time: " << getTimeDiff(t[0], t[1]) << " ms." << endl;
     cout << "Ranking the images." << endl;
 
     index->readLock();
@@ -326,18 +258,21 @@ u_int32_t ORBSearcher::searchSimilar(SearchRequest &request)
     priority_queue<SearchResult> rankedResults;
     for (unordered_map<unsigned, float>::const_iterator it = weights.begin();
          it != weights.end(); ++it)
+    {
+        cout << "Second: " << it->second << " First: " << it->first << endl;
         rankedResults.push(SearchResult(it->second, it->first, Rect()));
+    }
 
-    gettimeofday(&t[3], NULL);
-    cout << "time: " << getTimeDiff(t[2], t[3]) << " ms." << endl;
+    gettimeofday(&t[2], NULL);
+    cout << "time: " << getTimeDiff(t[1], t[2]) << " ms." << endl;
     cout << "Reranking 300 among " << rankedResults.size() << " images." << endl;
 
     priority_queue<SearchResult> rerankedResults;
     reranker.rerank(imageReqHits, indexHits,
                     rankedResults, rerankedResults, 300);
 
-    gettimeofday(&t[4], NULL);
-    cout << "time: " << getTimeDiff(t[3], t[4]) << " ms." << endl;
+    gettimeofday(&t[3], NULL);
+    cout << "time: " << getTimeDiff(t[2], t[3]) << " ms." << endl;
     cout << "Returning the results. " << endl;
 
     returnResults(rerankedResults, request, 100);

--- a/src/requesthandler.cpp
+++ b/src/requesthandler.cpp
@@ -187,6 +187,44 @@ void RequestHandler::handleRequest(ConnectionInfo &conInfo)
             ret["scores"] = scores;
         }
     }
+    else if (testURIWithPattern(parsedURI, p_image)
+        && conInfo.connectionType == GET)
+    {
+        SearchRequest req;
+
+        req.imageId = atoi(parsedURI[2].c_str());
+        req.client = NULL;
+        u_int32_t i_ret = imageSearcher->searchSimilar(req);
+
+        ret["type"] = Converter::codeToString(i_ret);
+
+        if (i_ret == SEARCH_RESULTS)
+        {
+            // Return the image ids
+            Json::Value imageIds(Json::arrayValue);
+            for (unsigned i = 0; i < req.results.size(); ++i)
+                imageIds.append(req.results[i]);
+            ret["image_ids"] = imageIds;
+
+            // Return the bounding rects
+            Json::Value boundingRects(Json::arrayValue);
+            for (unsigned i = 0; i < req.boundingRects.size(); ++i)
+            {
+                Rect r = req.boundingRects[i];
+                Json::Value rVal;
+                rVal["x"] = r.x; rVal["y"] = r.y;
+                rVal["width"] = r.width; rVal["height"] = r.height;
+                boundingRects.append(rVal);
+            }
+            ret["bounding_rects"] = boundingRects;
+
+            // Return the scores
+            Json::Value scores(Json::arrayValue);
+            for (unsigned i = 0; i < req.scores.size(); ++i)
+                scores.append(req.scores[i]);
+            ret["scores"] = scores;
+        }
+    }
     else if (testURIWithPattern(parsedURI, p_ioIndex)
              && conInfo.connectionType == POST)
     {


### PR DESCRIPTION
Thank you so much for creating the amazing Pastec project, @magwyz! This pull request adds a new API endpoint:

``` sh
$ curl http://127.0.0.1:4212/index/images/1221010341
{"bounding_rects":[{"height":356,"width":291,"x":34,"y":31},{"height":315,"width":290,"x":34,"y":71}],"image_ids":[1221010341,2694417911],"scores":[577,78],"type":"SEARCH_RESULTS"}
```

When you access it, providing an ID of an image that's already in the index, it will return a set of similar images that are also in the index. By default you will no longer have to re-upload an image to see what images are similar to it. Depending upon network latency, and the size of the image, this may have some performance improvements.

Additionally an optional image -> word cache is added (which can be enabled via a command-line option `--cache-words`) to dramatically improve performance, at the expense of memory usage.

| Type | Time to Respond | Memory Usage |
| --- | --- | --- |
| Cached In-Index Search | 1.02-1.14s | 877MB |
| Un-cached In-Index Search | 2.40-2.71s | 625MB |
| Image Upload Search | 3.43-3.55s | n/a |

This is with an index of 59,041 images at 419MB.

I'm sure many improvements can be made to this code, this is my first time writing C++ in many years so feedback is most appreciated! I'm planning on contributing a number of other pull requests as well. Namely being able to: configure the maximum number occurrences for a word,  set a string name for an image instead of a number, and being able to set a default index location.

(This branch unfortunately includes @ryanfb's Mac-platform pull request #21, as I needed it to get it to build on my copy of OSX.)
