### PR TITLE
httpserver: don't leak buffer on error

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -65,7 +65,10 @@ char *HTTPServer::loadFile(const char *filename)
         return NULL;
 
     if (!file.read(buffer, size))
+    {
+        delete[] buffer;
         return NULL;
+    }
 
     return buffer;
 }


### PR DESCRIPTION
Found by cppcheck. 

Please note I can't test the change because of #30
