### PR TITLE
Libjson fix

### DIFF
--- a/cmake/Modules/Findjsoncpp.cmake
+++ b/cmake/Modules/Findjsoncpp.cmake
@@ -9,9 +9,9 @@ find_package(PkgConfig)
 pkg_check_modules(PC_LIBJSONCPP QUIET libjsoncpp)
 set(LIBJSONCPP_DEFINITIONS ${PC_LIBJSONCPP_CFLAGS_OTHER})
 
-find_path(LIBJSONCPP_INCLUDE_DIR json.h
+find_path(LIBJSONCPP_INCLUDE_DIR json/features.h
           HINTS ${PC_LIBJSONCPP_INCLUDEDIR} ${PC_LIBJSONCPP_INCLUDE_DIRS}
-          PATH_SUFFIXES libjsoncpp)
+          PATH_SUFFIXES jsoncpp)
 
 find_library(LIBJSONCPP_LIBRARY jsoncpp
              HINTS ${PC_LIBJSONCPP_LIBDIR} ${PC_LIBJSONCPP_LIBRARY_DIRS} )


### PR DESCRIPTION
I have run into errors with your cmake file correctly locating libjsoncpp, both on OS X (10.10.5, with libjsoncpp installed via homebrew) as well as Ubuntu 14.04 (installed via apt-get). This has also been described in #30 

```
# cmake ../
-- The C compiler identification is GNU 4.8.4
-- The CXX compiler identification is GNU 4.8.4
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Looking for include file pthread.h
-- Looking for include file pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.26") 
-- Found libmicrohttpd: /usr/lib/x86_64-linux-gnu/libmicrohttpd.so  
-- Could NOT find libjsoncpp (missing:  LIBJSONCPP_INCLUDE_DIR) 
-- Configuring done
-- Generating done
-- Build files have been written to: /root/pastec/build
```

The following patch described in #8 fixes this for both OS X and Ubuntu. I have not yet tested it on other systems, however.
