### PR TITLE
fix for reverse search

### DIFF
--- a/include/backwardindexreaderaccess.h
+++ b/include/backwardindexreaderaccess.h
@@ -134,7 +134,7 @@ public:
         i_curPos = pos;
     }
 
-    virtual void read(char *p_data, unsigned i_nbBytes)
+    virtual void read(u_char *p_data, unsigned i_nbBytes)
     {
         memcpy(p_data, p_indexData + i_curPos, i_nbBytes);
         i_curPos += i_nbBytes;

--- a/include/featureextractor.h
+++ b/include/featureextractor.h
@@ -29,7 +29,7 @@ class FeatureExtractor
 {
 public:
     virtual u_int32_t processNewImage(unsigned i_imageId, unsigned i_imgSize,
-                                      char *p_imgData, unsigned &i_nbFeaturesExtracted) = 0;
+                                      u_char *p_imgData, unsigned &i_nbFeaturesExtracted) = 0;
 };
 
 #endif // PASTEC_FEATUREEXTRACTOR_H

--- a/include/httpserver.h
+++ b/include/httpserver.h
@@ -78,7 +78,7 @@ struct ConnectionInfo
     int answerCode;
     string authKey;
 
-    vector<char> uploadedData;
+    vector<u_char> uploadedData;
 };
 
 #endif // PASTEC_HTTPSERVER_H

--- a/include/imagedownloader.h
+++ b/include/imagedownloader.h
@@ -36,7 +36,7 @@ public:
     ImageDownloader();
 
     bool canDownloadImage(std::string imgURL);
-    u_int32_t getImageData(std::string imgURL, std::vector<char> &imgData,
+    u_int32_t getImageData(std::string imgURL, std::vector<u_char> &imgData,
                            long &responseCode);
 
 private:

--- a/include/imageloader.h
+++ b/include/imageloader.h
@@ -31,7 +31,7 @@ using namespace cv;
 class ImageLoader
 {
 public:
-    static u_int32_t loadImage(unsigned i_imgSize, char *p_imgData, Mat &img);
+    static u_int32_t loadImage(unsigned i_imgSize, u_char *p_imgData, Mat &img);
 };
 
 #endif // PASTEC_IMAGELOADER_H

--- a/include/orb/orbfeatureextractor.h
+++ b/include/orb/orbfeatureextractor.h
@@ -47,7 +47,7 @@ public:
     virtual ~ORBFeatureExtractor() {}
 
     u_int32_t processNewImage(unsigned i_imageId, unsigned i_imgSize,
-                              char *p_imgData, unsigned &i_nbFeaturesExtracted);
+                              u_char *p_imgData, unsigned &i_nbFeaturesExtracted);
 
 private:
     ORBIndex *index;

--- a/include/searcher.h
+++ b/include/searcher.h
@@ -36,7 +36,7 @@ class ClientConnection;
 struct SearchRequest
 {
     u_int32_t imageId;
-    vector<char> imageData;
+    vector<u_char> imageData;
     ClientConnection *client;
     vector<u_int32_t> results;
     vector<Rect> boundingRects;

--- a/src/imagedownloader.cpp
+++ b/src/imagedownloader.cpp
@@ -40,7 +40,7 @@ bool ImageDownloader::canDownloadImage(std::string imgURL)
 }
 
 
-u_int32_t ImageDownloader::getImageData(std::string imgURL, std::vector<char> &imgData,
+u_int32_t ImageDownloader::getImageData(std::string imgURL, std::vector<u_char> &imgData,
                                         long &responseCode)
 {
     if (!canDownloadImage(imgURL))

--- a/src/imageloader.cpp
+++ b/src/imageloader.cpp
@@ -29,14 +29,14 @@
 #include <messages.h>
 
 
-u_int32_t ImageLoader::loadImage(unsigned i_imgSize, char *p_imgData, Mat &img)
+u_int32_t ImageLoader::loadImage(unsigned i_imgSize, u_char *p_imgData, Mat &img)
 {
     vector<char> imgData(i_imgSize);
     memcpy(imgData.data(), p_imgData, i_imgSize);
 
     try
     {
-        img = imdecode(imgData, CV_LOAD_IMAGE_GRAYSCALE);
+        img = imdecode(imgData, IMREAD_GRAYSCALE);
     }
     catch (cv::Exception& e) // The decoding of an image can raise an exception.
     {

--- a/src/imagereranker.cpp
+++ b/src/imagereranker.cpp
@@ -61,6 +61,7 @@ void *RANSACThread::run()
             }
         }
     }
+    return NULL;
 }
 
 

--- a/src/orb/orbfeatureextractor.cpp
+++ b/src/orb/orbfeatureextractor.cpp
@@ -37,7 +37,7 @@ ORBFeatureExtractor::ORBFeatureExtractor(ORBIndex *index, ORBWordIndex *wordInde
 
 
 u_int32_t ORBFeatureExtractor::processNewImage(unsigned i_imageId, unsigned i_imgSize,
-                                               char *p_imgData, unsigned &i_nbFeaturesExtracted)
+                                               u_char *p_imgData, unsigned &i_nbFeaturesExtracted)
 {
     Mat img;
     u_int32_t i_ret = ImageLoader::loadImage(i_imgSize, p_imgData, img);

--- a/src/requesthandler.cpp
+++ b/src/requesthandler.cpp
@@ -153,7 +153,7 @@ void RequestHandler::handleRequest(ConnectionInfo &conInfo)
             string imgURL = data["url"].asString();
             if (imgDownloader->canDownloadImage(imgURL))
             {
-                std::vector<char> imgData;
+                std::vector<u_char> imgData;
                 long HTTPResponseCode;
                 i_ret = imgDownloader->getImageData(imgURL, imgData, HTTPResponseCode);
                 if (i_ret == OK)
@@ -219,7 +219,7 @@ void RequestHandler::handleRequest(ConnectionInfo &conInfo)
             string imgURL = data["url"].asString();
             if (imgDownloader->canDownloadImage(imgURL))
             {
-                std::vector<char> imgData;
+                std::vector<u_char> imgData;
                 long HTTPResponseCode;
                 i_ret = imgDownloader->getImageData(imgURL, imgData, HTTPResponseCode);
                 if (i_ret == OK)


### PR DESCRIPTION
This is a bugfix  update for Pastec. 
It crash if you start a imagesearch .. And it would not compile with opencv 4 
This is a fix for them .. 